### PR TITLE
Feature: Add User Registration

### DIFF
--- a/app/assets/stylesheets/components/_auth-forms.scss
+++ b/app/assets/stylesheets/components/_auth-forms.scss
@@ -120,8 +120,9 @@
     input[type="text"] {
       width: 100%;
       padding: 10px 12px;
-      font-family: var(--font-mono);
-      font-size: var(--font-size-form);
+      font-family: var(--font-caveat);
+      font-size: 18px;
+      font-weight: 500;
       color: var(--ink-primary);
       background: var(--paper-form-bg);
       border: var(--border-thin) solid var(--ink-primary-10);
@@ -140,6 +141,7 @@
       }
       
       &::placeholder {
+        font-family: var(--font-caveat);
         color: var(--ink-primary);
         opacity: 0.3;
         font-style: italic;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,25 @@
+class UsersController < ApplicationController
+  allow_unauthenticated_access only: %i[ new create ]
+  rate_limit to: 5, within: 3.minutes, only: :create, with: -> { redirect_to new_user_url, alert: "Try again later." }
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      start_new_session_for @user
+      redirect_to after_authentication_url, notice: "Welcome to Gournal!"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email_address, :password, :password_confirmation)
+  end
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -40,7 +40,7 @@
     <% end %>
     
     <div class="form-links">
-      <%= link_to "Create an account", new_user_path if defined?(new_user_path) %>
+      <%= link_to "Create an account", new_user_path %>
     </div>
   </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,64 @@
+<div class="auth-container">
+  <% if flash[:alert] %>
+    <div class="flash-message flash-alert" data-turbo-temporary>
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
+  
+  <% if flash[:notice] %>
+    <div class="flash-message flash-notice" data-turbo-temporary>
+      <%= flash[:notice] %>
+    </div>
+  <% end %>
+
+  <div class="auth-form">
+    <h1>Create your Gournal account</h1>
+    
+    <%= form_with model: @user, local: true do |form| %>
+      <% if @user.errors.any? %>
+        <div class="form-errors">
+          <% @user.errors.full_messages.each do |message| %>
+            <div class="error-message"><%= message %></div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div class="form-field">
+        <%= form.label :email_address, "Email" %>
+        <%= form.email_field :email_address, 
+            required: true, 
+            autofocus: true, 
+            autocomplete: "email",
+            placeholder: "your@email.com" %>
+      </div>
+      
+      <div class="form-field">
+        <%= form.label :password, "Password" %>
+        <%= form.password_field :password, 
+            required: true, 
+            autocomplete: "new-password",
+            placeholder: "••••••••",
+            minlength: 8,
+            maxlength: 72 %>
+      </div>
+      
+      <div class="form-field">
+        <%= form.label :password_confirmation, "Confirm Password" %>
+        <%= form.password_field :password_confirmation, 
+            required: true, 
+            autocomplete: "new-password",
+            placeholder: "••••••••",
+            minlength: 8,
+            maxlength: 72 %>
+      </div>
+      
+      <div class="form-submit">
+        <%= form.submit "Create account" %>
+      </div>
+    <% end %>
+    
+    <div class="form-links">
+      <%= link_to "Already have an account? Sign in", new_session_path %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resource :session
+  resources :users, only: [ :new, :create ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## Summary
• Add complete user registration functionality with email/password
• Create registration form matching existing Japanese aesthetic 
• Update authentication flow to support user sign-up
• Include proper validation, error handling, and rate limiting

## Changes Made
• **New UsersController**: Handles registration with `new` and `create` actions
• **Registration form**: Clean, responsive design matching sign-in form aesthetic
• **Handwritten typography**: Input fields use same font as daily reflections (`var(--font-caveat)`)
• **Auto-login**: Users automatically signed in after successful registration
• **Rate limiting**: Prevents registration spam (5 attempts per 3 minutes)
• **Navigation links**: Updated sign-in form to link to registration

## Test Plan
- [x] All existing tests pass (151 tests, 0 failures)
- [x] Style checks pass (rubocop clean)
- [x] Registration form renders correctly
- [x] User can create account with email/password
- [x] Validation works for invalid inputs
- [x] Auto-login works after registration
- [x] Links between sign-in/sign-up work properly
- [x] Handwritten font matches daily reflections

🤖 Generated with [Claude Code](https://claude.ai/code)