### PR TITLE
fix: Fix daily reflections persistence by using consistent authentication

### DIFF
--- a/app/controllers/daily_reflections_controller.rb
+++ b/app/controllers/daily_reflections_controller.rb
@@ -1,12 +1,8 @@
 class DailyReflectionsController < ApplicationController
-  allow_unauthenticated_access
-
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def create
-    user_email = ENV["FIRST_USER"]
-    @current_user = User.find_by(email_address: user_email)
-    @current_user ||= User.first
+    @current_user = Current.user
 
     unless @current_user
       return render json: {

--- a/test/controllers/daily_reflections_controller_test.rb
+++ b/test/controllers/daily_reflections_controller_test.rb
@@ -9,12 +9,11 @@ class DailyReflectionsControllerTest < ActionDispatch::IntegrationTest
       content: "Test reflection"
     )
 
-    # Mock ENV variable for user
-    ENV["FIRST_USER"] = @user.email_address
-  end
-
-  teardown do
-    ENV.delete("FIRST_USER")
+    # Sign in the user
+    post session_url, params: {
+      email_address: @user.email_address,
+      password: "password"  # Fixture password
+    }
   end
 
   test "create should create new reflection with valid params" do


### PR DESCRIPTION
## Summary
- Fixed daily reflections not persisting after page reload
- Root cause: Authentication mismatch between controllers
- Updated DailyReflectionsController to use Current.user consistently with the rest of the app

## Changes
- Removed ENV["FIRST_USER"] authentication pattern from DailyReflectionsController
- Updated controller to use Current.user from Rails authentication system
- Removed allow_unauthenticated_access since proper authentication is now required
- Updated tests to properly authenticate users instead of mocking environment variables

## Test plan
- [x] All existing tests pass
- [x] Manual test: Type reflection on root page, reload, confirm it persists
- [x] Verified authentication works consistently across controllers

🤖 Generated with [Claude Code](https://claude.ai/code)