### PR TITLE
fix: Remove automatic text selection when editing habit names

### DIFF
--- a/app/javascript/controllers/inline_habit_editor_controller.js
+++ b/app/javascript/controllers/inline_habit_editor_controller.js
@@ -239,9 +239,8 @@ export default class extends Controller {
     nameElement.parentElement.insertBefore(input, nameElement.nextSibling)
     nameElement.style.display = "none"
     
-    // Focus and select text
+    // Focus without selecting text
     input.focus()
-    input.select()
     
     // Add event listeners
     input.addEventListener("blur", () => this.saveEdit(input))


### PR DESCRIPTION
## Summary
- Fixed unwanted blue text highlighting when clicking on habit names in Settings page
- Removed automatic `input.select()` call that was causing browser text selection
- Preserves inline editing functionality while improving user experience

## Test plan
- [x] Click on habit names in Settings → Manage habits section
- [x] Verify no blue text highlighting appears
- [x] Confirm inline editing still works correctly
- [x] Test that focus is still properly set on input field

🤖 Generated with [Claude Code](https://claude.ai/code)