### PR TITLE
feat: Add public profile sharing with privacy controls

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,4 @@
 @use "components/month-setup";
 @use "components/help-page";
 @use "components/context-menu";
+@use "components/public-profile";

--- a/app/assets/stylesheets/components/_public-profile.scss
+++ b/app/assets/stylesheets/components/_public-profile.scss
@@ -1,0 +1,159 @@
+/* ============================================================================ */
+/* PUBLIC PROFILE - Read-only habit tracker for sharing                        */
+/* ============================================================================ */
+
+/* Public profile header additions */
+.public-profile-info {
+  text-align: center;
+  margin-top: var(--space-xs);
+}
+
+.profile-user-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--ink-primary);
+  opacity: var(--opacity-secondary);
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+/* Create Account CTA for unauthenticated users */
+.create-account-cta {
+  margin-top: var(--space-lg);
+  text-align: center;
+}
+
+.create-account-button {
+  display: inline-block;
+  padding: 12px 24px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--paper-light);
+  background: var(--ink-primary);
+  text-decoration: none;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all var(--duration-normal) var(--ease-standard);
+  box-sizing: border-box;
+  
+  /* Subtle rotation for handwritten feel */
+  transform: rotate(-0.3deg);
+  
+  &:hover {
+    background: var(--ink-hover);
+    color: var(--paper-light);
+    transform: rotate(0deg) scale(1.03);
+    box-shadow: 0 4px 12px rgba(26, 35, 50, 0.2);
+    text-decoration: none;
+  }
+  
+  &:active {
+    transform: rotate(0deg) scale(0.97);
+  }
+  
+  /* Mobile responsive */
+  @media (max-width: 480px) {
+    font-size: var(--text-xxs);
+    padding: 10px 20px;
+  }
+  
+  /* Secondary button variant for empty states */
+  &--secondary {
+    background: transparent;
+    color: var(--ink-primary);
+    border: var(--border-thin) solid var(--ink-primary);
+    transform: rotate(0.2deg);
+    
+    &:hover {
+      background: var(--ink-primary);
+      color: var(--paper-light);
+      border-color: var(--ink-primary);
+    }
+  }
+}
+
+/* Read-only habit grid modifications */
+.habit-grid--readonly {
+  /* Remove interactive elements cursor styles */
+  .habit-checkbox--readonly {
+    cursor: default;
+    pointer-events: none;
+  }
+  
+  .reflection-cell--readonly {
+    cursor: default;
+  }
+}
+
+/* Read-only reflection content */
+.reflection-content {
+  font-family: var(--font-caveat);
+  font-size: var(--text-md);
+  color: var(--ink-primary);
+  line-height: 1.4;
+  padding: var(--space-xs) 0;
+  
+  /* Remove the editable styling */
+  background: none;
+  border: none;
+  
+  /* Handle simple_format paragraphs */
+  p {
+    margin: 0 0 var(--space-xs) 0;
+    
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+/* Empty state for public profiles */
+.empty-state {
+  text-align: center;
+  padding: var(--space-xxl) var(--space-lg);
+}
+
+.empty-state-content {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.empty-state-message {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--ink-primary);
+  opacity: var(--opacity-secondary);
+  line-height: 1.5;
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.empty-state-cta {
+  margin-top: var(--space-lg);
+}
+
+/* Footer attribution */
+.public-profile-footer {
+  margin-top: var(--space-xxl);
+  padding-top: var(--space-lg);
+  border-top: var(--border-thin) solid var(--ink-primary-10);
+  text-align: center;
+}
+
+.attribution {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--ink-primary);
+  opacity: var(--opacity-secondary);
+  
+  a {
+    color: var(--ink-primary);
+    text-decoration: none;
+    
+    &:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_settings.scss
+++ b/app/assets/stylesheets/components/_settings.scss
@@ -62,3 +62,86 @@
   padding-left: 0;
   margin-left: 0;
 }
+
+/* Profile URL display with inline editing */
+.profile-url-section {
+  margin-bottom: var(--space-lg);
+}
+
+.profile-url-display {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-bottom: var(--space-sm);
+  line-height: 1.4;
+  position: relative;
+  
+  /* Add copy indicator after the full URL */
+  &::after {
+    content: "□";
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--ink-primary);
+    opacity: var(--opacity-secondary);
+    margin-left: var(--space-sm);
+    transition: all var(--duration-fast) var(--ease-standard);
+    cursor: pointer;
+  }
+  
+  &:hover {
+    cursor: pointer;
+    
+    &::after {
+      opacity: 1;
+      content: "⧉";
+    }
+  }
+  
+  /* Copied state feedback */
+  &.url-copied::after {
+    content: "✓";
+    opacity: 1;
+    color: var(--success-color, var(--ink-primary));
+  }
+}
+
+.profile-url-prefix {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--ink-primary);
+  opacity: var(--opacity-secondary);
+  white-space: nowrap;
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.profile-slug-editable {
+  font-family: var(--font-caveat);
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--ink-primary);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-standard);
+  padding: 2px 4px;
+  border-radius: 2px;
+  
+  &:hover {
+    background: var(--paper-hover);
+    text-decoration: underline;
+    text-decoration-style: wavy;
+    text-underline-offset: 3px;
+  }
+  
+  /* When no slug is set, make it look like placeholder */
+  &[data-placeholder="true"] {
+    opacity: var(--opacity-placeholder);
+    font-style: italic;
+  }
+}
+
+.field-error {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--ink-error);
+  margin-top: var(--space-xs);
+  letter-spacing: var(--letter-spacing-tight);
+}

--- a/app/controllers/habit_entries_controller.rb
+++ b/app/controllers/habit_entries_controller.rb
@@ -2,10 +2,21 @@ class HabitEntriesController < ApplicationController
   def index
     @current_user = Current.user
 
+    # Extract year and month from params or use current date
+    current_date = Date.current
+    year = params[:year]&.to_i || current_date.year
+    month = params[:month]&.to_i || current_date.month
+
+    # Validate year and month parameters
+    unless valid_date_params?(year, month)
+      year = current_date.year
+      month = current_date.month
+    end
+
     @tracker_data = HabitTrackerDataBuilder.call(
       user: @current_user,
-      year: 2025,
-      month: 9
+      year: year,
+      month: month
     )
 
     # If no user exists, show empty state
@@ -32,15 +43,24 @@ class HabitEntriesController < ApplicationController
   end
 
   def render_empty_state
+    current_date = Date.current
     @tracker_data = HabitTrackerData.new(
       habits: Habit.none,
       habit_entries_lookup: {},
       reflections_lookup: {},
-      month_name: "September",
-      days_in_month: 30,
-      year: 2025,
-      month: 9,
+      month_name: current_date.strftime("%B"),
+      days_in_month: current_date.end_of_month.day,
+      year: current_date.year,
+      month: current_date.month,
       user: nil
     )
+  end
+
+  def valid_date_params?(year, month)
+    return false unless year.is_a?(Integer) && month.is_a?(Integer)
+    return false unless year >= 2000 && year <= 2100
+    return false unless month >= 1 && month <= 12
+
+    true
   end
 end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -8,4 +8,8 @@ class HelpController < ApplicationController
   def next_month_setup
     # Help page for month setup process
   end
+
+  def profile_sharing
+    # Help page for profile sharing
+  end
 end

--- a/app/controllers/public_profiles_controller.rb
+++ b/app/controllers/public_profiles_controller.rb
@@ -1,0 +1,44 @@
+class PublicProfilesController < ApplicationController
+  allow_unauthenticated_access
+
+  def show
+    @user = User.find_by!(slug: params[:slug])
+
+    # Extract year and month from params or use current
+    current_date = Date.current
+    year = params[:year]&.to_i || current_date.year
+    month = params[:month]&.to_i || current_date.month
+
+    # Validate year and month parameters
+    unless valid_date_params?(year, month)
+      year = current_date.year
+      month = current_date.month
+    end
+
+    # Build tracker data with privacy checks
+    @tracker_data = PublicProfileDataBuilder.call(
+      user: @user,
+      year: year,
+      month: month
+    )
+
+    # Set current date for navigation
+    @current_date = Date.new(year, month, 1)
+    @current_year_month = @current_date.strftime("%Y-%m")
+
+    # Use the public profile view (not the habit_entries view)
+
+  rescue ActiveRecord::RecordNotFound
+    render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
+  end
+
+  private
+
+  def valid_date_params?(year, month)
+    return false unless year.is_a?(Integer) && month.is_a?(Integer)
+    return false unless year >= 2000 && year <= 2100
+    return false unless month >= 1 && month <= 12
+
+    true
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -13,4 +13,33 @@ class SettingsController < ApplicationController
                                       .exists?
     @next_month_date = next_month_date
   end
+
+  def update
+    @user = Current.user
+
+    if @user.update(user_params)
+      redirect_to settings_path, notice: "Profile settings updated successfully"
+    else
+      # Re-render index with errors
+      current_date = Date.current
+      @habits = Current.user.habits
+                       .where(year: current_date.year, month: current_date.month, active: true)
+                       .order(:position)
+
+      # Check if next month already has habits
+      next_month_date = current_date.next_month
+      @next_month_habits_exist = Current.user.habits
+                                        .where(year: next_month_date.year, month: next_month_date.month, active: true)
+                                        .exists?
+      @next_month_date = next_month_date
+
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:slug, :habits_public, :reflections_public)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,18 @@ module ApplicationHelper
     CheckboxRenderer.call(habit_entry: habit_entry, view_context: self)
   end
 
+  def render_public_habit_checkbox(habit_entry)
+    content_tag(:div, class: "checkbox-container") do
+      if !habit_entry&.completed?
+        render("checkboxes/box_0")
+      elsif habit_entry.habit.x_marks?
+        render("checkboxes/box_0") + render("checkboxes/x_0")
+      else
+        render("checkboxes/box_0") + render("checkboxes/blot_0")
+      end
+    end
+  end
+
   # Format date as "Month Year" (e.g., "October 2024")
   def format_month_year(year, month = nil)
     if year.respond_to?(:strftime)

--- a/app/javascript/controllers/privacy_settings_controller.js
+++ b/app/javascript/controllers/privacy_settings_controller.js
@@ -1,0 +1,241 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { 
+    xMarks: Array
+  }
+  
+  static targets = [
+    "form",
+    "slugDisplay",
+    "slugField", 
+    "urlDisplay",
+    "habitsPublicField",
+    "reflectionsPublicField",
+    "submitButton",
+    "option"
+  ]
+
+  connect() {
+    this.markIndex = 0
+    this.editingElement = null
+    this.originalSlug = null
+    
+    // Initialize checkbox states based on current values
+    this.initializeCheckboxStates()
+  }
+  
+  initializeCheckboxStates() {
+    // Set initial checkbox states based on field values
+    this.updateCheckboxDisplay('habits_public', this.habitsPublicFieldTarget.value === 'true')
+    this.updateCheckboxDisplay('reflections_public', this.reflectionsPublicFieldTarget.value === 'true')
+  }
+
+  toggleOption(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    
+    const clickedElement = event.currentTarget
+    const option = clickedElement.dataset.option
+    const fieldTarget = option === 'habits_public' ? this.habitsPublicFieldTarget : this.reflectionsPublicFieldTarget
+    
+    // Toggle the value
+    const currentValue = fieldTarget.value === 'true'
+    const newValue = !currentValue
+    
+    // Update the field and display
+    fieldTarget.value = newValue
+    this.updateCheckboxDisplay(option, newValue)
+  }
+  
+  updateCheckboxDisplay(option, isChecked) {
+    const checkboxContainer = this.getCheckboxContainerForOption(option)
+    if (!checkboxContainer) return
+    
+    if (isChecked) {
+      // Get next X mark variant from the randomized array
+      const xVariant = this.xMarksValue[this.markIndex]
+      this.markIndex = (this.markIndex + 1) % this.xMarksValue.length
+      
+      // Hide all X marks first
+      checkboxContainer.querySelectorAll('.checkbox-x-wrapper').forEach(wrapper => {
+        wrapper.style.display = 'none'
+      })
+      
+      // Show the selected X mark variant
+      const selectedWrapper = checkboxContainer.querySelector(`[data-x-variant="${xVariant}"]`)
+      if (selectedWrapper) {
+        selectedWrapper.style.display = 'block'
+      }
+    } else {
+      // Hide all X marks
+      checkboxContainer.querySelectorAll('.checkbox-x-wrapper').forEach(wrapper => {
+        wrapper.style.display = 'none'
+      })
+    }
+  }
+  
+  getCheckboxContainerForOption(option) {
+    // Find the option target that matches this option field
+    const optionElement = this.optionTargets.find(target => 
+      target.dataset.optionField === option
+    )
+    
+    if (optionElement) {
+      return optionElement.querySelector('.checkbox-container')
+    }
+    
+    return null
+  }
+
+  // Slug editing functionality
+  editSlug(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    
+    if (this.editingElement) return // Already editing
+    
+    const slugElement = this.slugDisplayTarget
+    this.startInlineEdit(slugElement)
+  }
+  
+  startInlineEdit(slugElement) {
+    // Store editing state
+    this.originalSlug = slugElement.textContent.trim()
+    this.editingElement = slugElement
+    
+    // Check if it's showing placeholder text
+    const isPlaceholder = slugElement.dataset.placeholder === "true"
+    const currentText = isPlaceholder ? "" : this.originalSlug
+    
+    // Create input element
+    const input = document.createElement("input")
+    input.type = "text"
+    input.value = currentText
+    input.className = "habit-input habit-input--editing"
+    input.placeholder = "your-custom-share-link"
+    
+    // Replace element content with input
+    slugElement.innerHTML = ""
+    slugElement.appendChild(input)
+    
+    // Focus and select text
+    input.focus()
+    if (currentText) {
+      input.select()
+    }
+    
+    // Add event listeners
+    input.addEventListener("blur", () => this.finishEdit())
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault()
+        this.finishEdit()
+      } else if (e.key === "Escape") {
+        this.cancelEdit()
+      }
+    })
+  }
+  
+  finishEdit() {
+    if (!this.editingElement) return
+    
+    const input = this.editingElement.querySelector("input")
+    if (!input) return
+    
+    const newSlug = input.value.trim()
+    const isValid = this.validateSlug(newSlug)
+    
+    if (isValid) {
+      // Update the slug field
+      this.slugFieldTarget.value = newSlug
+      
+      // Update display
+      this.editingElement.textContent = newSlug || "your-custom-share-link"
+      this.editingElement.dataset.placeholder = newSlug ? "false" : "true"
+      
+      // Auto-submit the form to save the slug
+      this.formTarget.requestSubmit()
+    } else {
+      // Invalid slug, revert to original
+      this.cancelEdit()
+    }
+    
+    this.editingElement = null
+    this.originalSlug = null
+  }
+  
+  cancelEdit() {
+    if (!this.editingElement) return
+    
+    // Restore original text
+    const displayText = this.originalSlug || "your-custom-share-link"
+    this.editingElement.textContent = displayText
+    this.editingElement.dataset.placeholder = this.originalSlug ? "false" : "true"
+    
+    this.editingElement = null
+    this.originalSlug = null
+  }
+  
+  validateSlug(slug) {
+    // Allow empty (will be handled as null)
+    if (!slug) return true
+    
+    // Check format: lowercase letters, numbers, underscores, and dashes only
+    const slugPattern = /^[a-z0-9_-]+$/
+    
+    // Check length: 3-30 characters
+    return slug.length >= 3 && slug.length <= 30 && slugPattern.test(slug)
+  }
+
+  // URL copying functionality
+  copyUrl(event) {
+    event.preventDefault()
+    
+    // Don't copy if clicking on the editable slug part
+    if (event.target.closest('.profile-slug-editable')) {
+      return
+    }
+    
+    const slug = this.slugFieldTarget.value
+    if (!slug) {
+      // No slug set, can't copy
+      return
+    }
+    
+    const fullUrl = `https://verynormal.dev/${slug}`
+    
+    // Copy to clipboard
+    navigator.clipboard.writeText(fullUrl).then(() => {
+      // Show feedback - temporarily change the copy icon
+      this.showCopyFeedback()
+    }).catch(() => {
+      // Fallback for older browsers
+      this.fallbackCopy(fullUrl)
+    })
+  }
+  
+  showCopyFeedback() {
+    const urlDisplay = this.urlDisplayTarget
+    
+    // Temporarily add copied class for styling
+    urlDisplay.classList.add('url-copied')
+    
+    // Remove after 2 seconds
+    setTimeout(() => {
+      urlDisplay.classList.remove('url-copied')
+    }, 2000)
+  }
+  
+  fallbackCopy(text) {
+    // Create temporary text area for copying
+    const textArea = document.createElement('textarea')
+    textArea.value = text
+    document.body.appendChild(textArea)
+    textArea.select()
+    document.execCommand('copy')
+    document.body.removeChild(textArea)
+    
+    this.showCopyFeedback()
+  }
+}

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -32,4 +32,6 @@ class Habit < ApplicationRecord
   # Scopes
   scope :current_month, ->(year, month) { where(year: year, month: month) }
   scope :ordered, -> { order(:position) }
+  scope :active, -> { where(active: true) }
+  scope :positioned, -> { order(:position) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,29 @@ class User < ApplicationRecord
                            format: { with: URI::MailTo::EMAIL_REGEXP,
                                    message: "must be a valid email address" }
 
+  validates :slug, uniqueness: { case_sensitive: false },
+                   format: { with: /\A[a-z0-9_-]+\z/,
+                            message: "can only contain lowercase letters, numbers, underscores, and dashes" },
+                   length: { minimum: 3, maximum: 30 },
+                   allow_blank: true
+
   # Normalizations
   normalizes :email_address, with: ->(e) { e.strip.downcase }
+  normalizes :slug, with: ->(s) { s.strip.downcase if s.present? }
+
+  # Scopes
+  scope :with_slug, -> { where.not(slug: [ nil, "" ]) }
+
+  # Public profile methods
+  def has_public_profile?
+    slug.present?
+  end
+
+  def public_habits_visible?
+    habits_public? && has_public_profile?
+  end
+
+  def public_reflections_visible?
+    reflections_public? && has_public_profile?
+  end
 end

--- a/app/services/public_profile_data_builder.rb
+++ b/app/services/public_profile_data_builder.rb
@@ -1,0 +1,86 @@
+class PublicProfileDataBuilder
+  def self.call(user:, year: Date.current.year, month: Date.current.month)
+    new(user: user, year: year, month: month).call
+  end
+
+  def initialize(user:, year:, month:)
+    raise ArgumentError, "User cannot be nil" if user.nil?
+
+    @user = user
+    @year = year
+    @month = month
+  end
+
+  def call
+    # Return empty data if user has no public profile
+    unless @user.has_public_profile?
+      return create_empty_data
+    end
+
+    HabitTrackerData.new(
+      habits: fetch_public_habits,
+      habit_entries_lookup: build_entries_lookup,
+      reflections_lookup: build_public_reflections_lookup,
+      month_name: month_name,
+      days_in_month: days_in_month,
+      year: @year,
+      month: @month,
+      user: @user
+    )
+  end
+
+  private
+
+  def fetch_public_habits
+    return Habit.none unless @user.public_habits_visible?
+
+    @habits ||= @user.habits
+      .includes(:habit_entries)
+      .where(year: @year, month: @month, active: true)
+      .ordered
+  end
+
+  def build_entries_lookup
+    lookup = {}
+    return lookup unless @user.public_habits_visible?
+
+    fetch_public_habits.each do |habit|
+      habit.habit_entries.each do |entry|
+        lookup[[ habit.id, entry.day ]] = entry
+      end
+    end
+    lookup
+  end
+
+  def build_public_reflections_lookup
+    lookup = {}
+    return lookup unless @user.public_reflections_visible?
+
+    reflections = @user.daily_reflections.for_month(@year, @month)
+    reflections.each do |reflection|
+      lookup[reflection.date.day] = reflection
+    end
+    lookup
+  end
+
+  def create_empty_data
+    HabitTrackerData.new(
+      habits: Habit.none,
+      habit_entries_lookup: {},
+      reflections_lookup: {},
+      month_name: month_name,
+      days_in_month: days_in_month,
+      year: @year,
+      month: @month,
+      user: @user
+    )
+  end
+
+  def month_name
+    Date.new(@year, @month, 1).strftime("%B")
+  end
+
+  def days_in_month
+    Date.new(@year, @month, -1).day
+  end
+end

--- a/app/views/habit_entries/index.html.erb
+++ b/app/views/habit_entries/index.html.erb
@@ -12,62 +12,11 @@
       </header>
       
       <%# Grid Layout: Day numbers + Habit columns + Reflection column %>
-      <div class="habit-grid" data-csrf-token="<%= form_authenticity_token %>">
-        
-        <%# Column Headers %>
-        <div class="grid-headers">
-          <div class="day-column-header"></div>
-          <% @tracker_data.habits.each do |habit| %>
-            <div class="habit-column-header">
-              <span class="habit-name"><%= habit.name %></span>
-            </div>
-          <% end %>
-          <div class="reflection-column-header">
-            <span class="reflection-label">Reflection</span>
-          </div>
-        </div>
-        
-        <%# Grid Rows: One row per day %>
-        <div class="grid-rows">
-          <% @tracker_data.days.each do |day| %>
-            <div class="day-row" data-day="<%= day %>">
-              
-              <%# Day Number %>
-              <div class="day-number"><%= day %></div>
-              
-              <%# Habit Checkboxes %>
-              <% @tracker_data.habits.each do |habit| %>
-                <div class="habit-checkbox">
-                  <% entry = @tracker_data.habit_entry_for(habit.id, day) %>
-                  <% if entry %>
-                    <%= render_habit_checkbox(entry) %>
-                  <% end %>
-                </div>
-              <% end %>
-              
-              <%# Reflection Column %>
-              <div class="reflection-cell">
-                <% reflection = @tracker_data.reflection_for(day) %>
-                <% reflection_date = Date.new(@tracker_data.year, @tracker_data.month, day) %>
-                <div 
-                  class="reflection-input"
-                  contenteditable="true"
-                  data-controller="reflection-editor"
-                  data-reflection-editor-id-value="<%= reflection&.id %>"
-                  data-reflection-editor-date-value="<%= reflection_date.iso8601 %>"
-                  data-reflection-editor-user-id-value="<%= @tracker_data.user&.id %>"
-                  data-action="input->reflection-editor#onInput blur->reflection-editor#onBlur"
-                  aria-label="Daily reflection for <%= format_full_date(reflection_date) %>"
-                  role="textbox"
-                  tabindex="0"
-                  data-placeholder=""><%= reflection&.content %></div>
-              </div>
-              
-            </div>
-          <% end %>
-        </div>
-        
-      </div>
+      <%= render 'shared/habit_grid', 
+          tracker_data: @tracker_data,
+          read_only: false,
+          show_habits: true,
+          show_reflections: true %>
       
     </div>
   </div>

--- a/app/views/help/profile_sharing.html.erb
+++ b/app/views/help/profile_sharing.html.erb
@@ -1,0 +1,91 @@
+<%# Help page for profile sharing %>
+<div class="paper-background">
+  <div class="container">
+    <div class="dot-grid-overlay">
+      
+      <%# Back button %>
+      <div class="settings-link-container">
+        <%= link_to "<", settings_path, class: "settings-link" %>
+      </div>
+      
+      <%# Header %>
+      <header class="month-header">
+        <h1>Profile Sharing Help</h1>
+      </header>
+      
+      <%# Help Content %>
+      <div class="help-content">
+        
+        <section class="help-section">
+          <h2 class="help-section-title">What is profile sharing?</h2>
+          <div class="help-text">
+            <p>Profile sharing lets you create a public view of your habit tracking progress to share with friends, accountability partners, or the community while maintaining full control over what's visible</p>
+          </div>
+        </section>
+        
+        <section class="help-section">
+          <h2 class="help-section-title">Setting up your public profile</h2>
+          <div class="help-text">
+            <p><strong>1. Choose your custom URL</strong></p>
+            <p>• Click on "your-custom-share-link" to edit your unique profile URL</p>
+            <p>• Your slug can contain lowercase letters, numbers, dashes, and underscores</p>
+            <p>• Example: verynormal.dev/jane-doe</p>
+            <p></p>
+            <p><strong>2. Select what to share</strong></p>
+            <p>• Use the checkboxes to control what appears on your public profile</p>
+            <p>• "Share my habits publicly" shows your habit names and completion status</p>
+            <p>• "Share my daily reflections publicly" shows your reflection notes</p>
+            <p></p>
+            <p><strong>3. Save your settings</strong></p>
+            <p>• Click "Save profile settings" to activate your public profile</p>
+            <p>• You can change these settings at any time</p>
+          </div>
+        </section>
+        
+        <section class="help-section">
+          <h2 class="help-section-title">Privacy controls</h2>
+          <div class="help-text">
+            <p>• Your profile is only visible if you set a custom URL</p>
+            <p>• Each privacy setting works independently</p>
+            <p>• Unchecking a box immediately hides that data</p>
+            <p>• Removing your slug disables your public profile entirely</p>
+          </div>
+        </section>
+        
+        <section class="help-section">
+          <h2 class="help-section-title">Sharing your profile</h2>
+          <div class="help-text">
+            <p>• Once you've saved your settings, your public profile is available at verynormal.dev/[your-slug]</p>
+            <p>• Click on your profile URL to copy it to your clipboard</p>
+            <p>• The small box icon (□) changes to indicate copying (⧉)</p>
+            <p>• Share this link with anyone you'd like to see your progress</p>
+            <p>• They don't need an account to view your public profile</p>
+          </div>
+        </section>
+        
+        <section class="help-section">
+          <h2 class="help-section-title">What visitors see</h2>
+          <div class="help-text">
+            <p>• The current month's habit tracker (if habits are public)</p>
+            <p>• Your daily reflections (if reflections are public)</p>
+            <p>• A read-only view - they cannot modify your data</p>
+            <p>• An invitation to create their own tracker</p>
+            <p>• Your email address and other personal information are never shown</p>
+          </div>
+        </section>
+        
+        <section class="help-section">
+          <h2 class="help-section-title">Tips for sharing</h2>
+          <div class="help-text">
+            <p>• Choose a memorable slug that represents you</p>
+            <p>• Consider what level of detail you're comfortable sharing</p>
+            <p>• You can temporarily disable sharing by unchecking both boxes</p>
+            <p>• Update your privacy settings as your comfort level changes</p>
+          </div>
+        </section>
+        
+      </div>
+      
+    </div>
+  </div>
+</div>

--- a/app/views/public_profiles/show.html.erb
+++ b/app/views/public_profiles/show.html.erb
@@ -1,0 +1,61 @@
+<%# Public Profile View - Read-only habit tracker %>
+<div class="paper-background">
+  <div class="container">
+    <div class="dot-grid-overlay">
+      
+      <%# Header with user name and month/year %>
+      <header class="month-header">
+        <h1><%= @tracker_data.month_name %> <%= @tracker_data.year %></h1>
+        <div class="public-profile-info">
+          <span class="profile-user-name">@<%= @user.slug %></span>
+        </div>
+        
+        <%# Create Account CTA for unauthenticated users %>
+        <% unless authenticated? %>
+          <div class="create-account-cta">
+            <%= link_to "Create your own Gournal", new_user_path, class: "create-account-button" %>
+          </div>
+        <% end %>
+      </header>
+      
+      <% if @tracker_data.empty? %>
+        <%# Empty state when no public data is available %>
+        <div class="empty-state">
+          <div class="empty-state-content">
+            <div class="empty-state-message">
+              <% if !@user.has_public_profile? %>
+                This user hasn't set up a public profile yet.
+              <% elsif !@user.public_habits_visible? && !@user.public_reflections_visible? %>
+                This user hasn't shared any data publicly.
+              <% else %>
+                No habits for this month.
+              <% end %>
+            </div>
+            
+            <%# Additional CTA in empty state for unauthenticated users %>
+            <% unless authenticated? %>
+              <div class="empty-state-cta">
+                <%= link_to "Create your own Gournal", new_user_path, class: "create-account-button create-account-button--secondary" %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% else %>
+        <%# Use shared habit grid partial with read-only mode %>
+        <%= render 'shared/habit_grid', 
+            tracker_data: @tracker_data,
+            read_only: true,
+            show_habits: @user.public_habits_visible?,
+            show_reflections: @user.public_reflections_visible? %>
+      <% end %>
+      
+      <%# Footer with attribution %>
+      <footer class="public-profile-footer">
+        <div class="attribution">
+          Powered by <a href="https://verynormal.dev" target="_blank">verynormal.dev</a>
+        </div>
+      </footer>
+      
+    </div>
+  </div>
+</div>

--- a/app/views/settings/_profile_sharing_section.html.erb
+++ b/app/views/settings/_profile_sharing_section.html.erb
@@ -1,0 +1,113 @@
+<%# Profile sharing form section %>
+<%
+  x_marks = JSON.parse(random_x_marks_json)
+%>
+
+<div data-controller="privacy-settings" 
+     data-privacy-settings-x-marks-value="<%= random_x_marks_json %>">
+  
+  <%= form_with model: user, 
+                url: settings_path,
+                method: :patch,
+                data: { 
+                  privacy_settings_target: "form"
+                },
+                class: "month-setup-form" do |form| %>
+    
+    <%# Profile URL display with inline editing %>
+    <div class="profile-url-section">
+      <div class="profile-url-display"
+           data-privacy-settings-target="urlDisplay"
+           data-action="click->privacy-settings#copyUrl">
+        <span class="profile-url-prefix">verynormal.dev/</span>
+        <span class="profile-slug-editable" 
+              data-privacy-settings-target="slugDisplay"
+              data-action="click->privacy-settings#editSlug"
+              <%= user.slug.blank? ? 'data-placeholder="true"' : '' %>>
+          <%= user.slug.present? ? user.slug : "your-custom-share-link" %>
+        </span>
+      </div>
+      <%= form.hidden_field :slug, 
+                           value: user.slug,
+                           data: { privacy_settings_target: "slugField" } %>
+      <% if user.errors[:slug].any? %>
+        <div class="field-error">
+          <%= user.errors[:slug].first %>
+        </div>
+      <% end %>
+    </div>
+    
+    <%# Privacy toggles %>
+    <div class="month-setup-options">
+      <div class="settings-description">What to share:</div>
+      
+      <%# Habits privacy toggle %>
+      <div class="month-setup-option" 
+           data-privacy-settings-target="option"
+           data-option-field="habits_public">
+        <div class="checkbox-label-container"
+             data-action="click->privacy-settings#toggleOption"
+             data-option="habits_public">
+          <div class="checkbox-container">
+            <%= render "checkboxes/box_0" %>
+            <% if user.habits_public? %>
+              <div class="checkbox-x-wrapper" data-x-variant="0">
+                <%= render "checkboxes/x_0" %>
+              </div>
+            <% end %>
+            <% x_marks.each do |variant| %>
+              <div class="checkbox-x-wrapper" data-x-variant="<%= variant %>" style="display: none;">
+                <%= render "checkboxes/x_#{variant}" %>
+              </div>
+            <% end %>
+          </div>
+          <label class="month-setup-label">
+            Share my habits publicly
+          </label>
+        </div>
+        <%= form.hidden_field :habits_public, 
+                             value: user.habits_public?,
+                             data: { privacy_settings_target: "habitsPublicField" } %>
+      </div>
+      
+      <%# Reflections privacy toggle %>
+      <div class="month-setup-option"
+           data-privacy-settings-target="option"
+           data-option-field="reflections_public">
+        <div class="checkbox-label-container"
+             data-action="click->privacy-settings#toggleOption"
+             data-option="reflections_public">
+          <div class="checkbox-container">
+            <%= render "checkboxes/box_0" %>
+            <% if user.reflections_public? %>
+              <div class="checkbox-x-wrapper" data-x-variant="0">
+                <%= render "checkboxes/x_0" %>
+              </div>
+            <% end %>
+            <% x_marks.each do |variant| %>
+              <div class="checkbox-x-wrapper" data-x-variant="<%= variant %>" style="display: none;">
+                <%= render "checkboxes/x_#{variant}" %>
+              </div>
+            <% end %>
+          </div>
+          <label class="month-setup-label">
+            Share my daily reflections publicly
+          </label>
+        </div>
+        <%= form.hidden_field :reflections_public, 
+                             value: user.reflections_public?,
+                             data: { privacy_settings_target: "reflectionsPublicField" } %>
+      </div>
+      
+    </div>
+    
+    <%# Submit button %>
+    <button type="submit" 
+            class="month-setup-submit"
+            data-privacy-settings-target="submitButton">
+      Save profile settings
+    </button>
+    
+  <% end %>
+  
+</div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -38,9 +38,12 @@
         
         <%# Section 3: Profile & Sharing %>
         <section class="settings-section profile-sharing">
-          <h2 class="settings-section-title">Profile & Sharing</h2>
+          <div class="section-header">
+            <h2 class="settings-section-title">Profile sharing</h2>
+            <%= link_to "(?)", help_profile_sharing_path, class: "help-button" %>
+          </div>
           <div class="section-content">
-            <%# Profile and sharing settings will go here %>
+            <%= render "profile_sharing_section", user: @user %>
           </div>
         </section>
         

--- a/app/views/shared/_habit_grid.html.erb
+++ b/app/views/shared/_habit_grid.html.erb
@@ -1,0 +1,17 @@
+<%# Shared habit grid structure - accepts tracker_data and read_only flag %>
+<div class="habit-grid<%= ' habit-grid--readonly' if local_assigns[:read_only] %>" <%= 'data-csrf-token="' + form_authenticity_token + '"' unless local_assigns[:read_only] %>>
+  
+  <%# Column Headers %>
+  <%= render 'shared/habit_grid_headers', 
+      tracker_data: tracker_data, 
+      show_habits: local_assigns[:show_habits] != false,
+      show_reflections: local_assigns[:show_reflections] != false %>
+  
+  <%# Grid Rows: One row per day %>
+  <%= render 'shared/habit_grid_rows', 
+      tracker_data: tracker_data,
+      read_only: local_assigns[:read_only] || false,
+      show_habits: local_assigns[:show_habits] != false,
+      show_reflections: local_assigns[:show_reflections] != false %>
+  
+</div>

--- a/app/views/shared/_habit_grid_headers.html.erb
+++ b/app/views/shared/_habit_grid_headers.html.erb
@@ -1,0 +1,16 @@
+<%# Grid column headers %>
+<div class="grid-headers">
+  <div class="day-column-header"></div>
+  <% if local_assigns[:show_habits] != false %>
+    <% tracker_data.habits.each do |habit| %>
+      <div class="habit-column-header">
+        <span class="habit-name"><%= habit.name %></span>
+      </div>
+    <% end %>
+  <% end %>
+  <% if local_assigns[:show_reflections] != false %>
+    <div class="reflection-column-header">
+      <span class="reflection-label">Reflection</span>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_habit_grid_rows.html.erb
+++ b/app/views/shared/_habit_grid_rows.html.erb
@@ -1,0 +1,57 @@
+<%# Grid rows for each day %>
+<div class="grid-rows">
+  <% tracker_data.days.each do |day| %>
+    <div class="day-row" data-day="<%= day %>">
+      
+      <%# Day Number %>
+      <div class="day-number"><%= day %></div>
+      
+      <%# Habit Checkboxes %>
+      <% if local_assigns[:show_habits] != false %>
+        <% tracker_data.habits.each do |habit| %>
+          <div class="habit-checkbox<%= ' habit-checkbox--readonly' if local_assigns[:read_only] %>">
+            <% entry = tracker_data.habit_entry_for(habit.id, day) %>
+            <% if entry %>
+              <% if local_assigns[:read_only] %>
+                <%= render_public_habit_checkbox(entry) %>
+              <% else %>
+                <%= render_habit_checkbox(entry) %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+      
+      <%# Reflection Column %>
+      <% if local_assigns[:show_reflections] != false %>
+        <div class="reflection-cell<%= ' reflection-cell--readonly' if local_assigns[:read_only] %>">
+          <% reflection = tracker_data.reflection_for(day) %>
+          <% if local_assigns[:read_only] %>
+            <%# Read-only reflection display %>
+            <% if reflection&.content.present? %>
+              <div class="reflection-content">
+                <%= simple_format(reflection.content) %>
+              </div>
+            <% end %>
+          <% else %>
+            <%# Editable reflection %>
+            <% reflection_date = Date.new(tracker_data.year, tracker_data.month, day) %>
+            <div 
+              class="reflection-input"
+              contenteditable="true"
+              data-controller="reflection-editor"
+              data-reflection-editor-id-value="<%= reflection&.id %>"
+              data-reflection-editor-date-value="<%= reflection_date.iso8601 %>"
+              data-reflection-editor-user-id-value="<%= tracker_data.user&.id %>"
+              data-action="input->reflection-editor#onInput blur->reflection-editor#onBlur"
+              aria-label="Daily reflection for <%= format_full_date(reflection_date) %>"
+              role="textbox"
+              tabindex="0"
+              data-placeholder=""><%= reflection&.content %></div>
+          <% end %>
+        </div>
+      <% end %>
+      
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,10 +16,12 @@ Rails.application.routes.draw do
 
   # Settings (authenticated)
   get "settings" => "settings#index", as: :settings
+  patch "settings" => "settings#update"
 
   # Help system (authenticated)
   get "help/manage-habits" => "help#manage_habits", as: :help_manage_habits
   get "help/next-month-setup" => "help#next_month_setup", as: :help_next_month_setup
+  get "help/profile-sharing" => "help#profile_sharing", as: :help_profile_sharing
 
   # Batch position updates for habits (must come before generic :habits routes)
   namespace :habits do
@@ -33,6 +35,8 @@ Rails.application.routes.draw do
   resources :habits, only: [ :new, :create, :update, :destroy ]
 
   # Habit entries routes
+  get "habit_entries/:year/:month", to: "habit_entries#index", as: :habit_entries_month,
+      constraints: { year: /\d{4}/, month: /\d{1,2}/ }
   resources :habit_entries, only: [ :index, :update ]
 
   # Daily reflections - top level resource since they belong to users
@@ -40,4 +44,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "habit_entries#index"
-end#
+
+  # Catch-all routes for public profiles (must be last to avoid conflicts)
+  get "/:slug/:year/:month", to: "public_profiles#show", as: :public_profile_month,
+      constraints: { slug: /[a-z0-9_-]+/, year: /\d{4}/, month: /\d{1,2}/ }
+  get "/:slug", to: "public_profiles#show", as: :public_profile,
+      constraints: { slug: /[a-z0-9_-]+/ }
+end

--- a/db/migrate/20250906170720_add_public_sharing_to_users.rb
+++ b/db/migrate/20250906170720_add_public_sharing_to_users.rb
@@ -1,0 +1,8 @@
+class AddPublicSharingToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :slug, :string
+    add_index :users, :slug, unique: true
+    add_column :users, :habits_public, :boolean, default: false, null: false
+    add_column :users, :reflections_public, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_29_144631) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_06_170720) do
   create_table "daily_reflections", force: :cascade do |t|
     t.integer "user_id", null: false
     t.date "date", null: false
@@ -61,7 +61,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_29_144631) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slug"
+    t.boolean "habits_public", default: false, null: false
+    t.boolean "reflections_public", default: false, null: false
     t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
+    t.index [ "slug" ], name: "index_users_on_slug", unique: true
   end
 
   add_foreign_key "daily_reflections", "users"

--- a/tasks/tasks-habit-tracking-setup-prd.md
+++ b/tasks/tasks-habit-tracking-setup-prd.md
@@ -109,18 +109,18 @@ Implementation tasks for comprehensive habit management system including setting
 
 
 - [ ] 6.0 Public Profile Sharing Feature
-  - [ ] 6.1 Generate migration for slug and privacy fields
-  - [ ] 6.2 Update User model with slug/privacy validations
-  - [ ] 6.3 Generate PublicProfilesController
-  - [ ] 6.4 Add catch-all route for /:slug
-  - [ ] 6.5 Add slug input to settings profile section
-  - [ ] 6.6 Add privacy toggles (habits/reflections) to settings
-  - [ ] 6.7 Create privacy_settings Stimulus controller
-  - [ ] 6.8 Implement public profile show action with privacy checks
-  - [ ] 6.9 Create public_profiles/show.html.erb (read-only view)
-  - [ ] 6.10 Add "Create Account" button for non-auth users
-  - [ ] 6.11 Remove ENV["FIRST_USER"] hardcoding
-  - [ ] 6.12 Write tests for privacy and public access
+  - [x] 6.1 Generate migration for slug and privacy fields
+  - [x] 6.2 Update User model with slug/privacy validations
+  - [x] 6.3 Generate PublicProfilesController
+  - [x] 6.4 Add catch-all route for /:slug
+  - [x] 6.5 Add slug input to settings profile section
+  - [x] 6.6 Add privacy toggles (habits/reflections) to settings
+  - [x] 6.7 Create privacy_settings Stimulus controller
+  - [x] 6.8 Implement public profile show action with privacy checks
+  - [x] 6.9 Create public_profiles/show.html.erb (read-only view)
+  - [x] 6.10 Add "Create Account" button for non-auth users
+  - [x] 6.11 Remove ENV["FIRST_USER"] hardcoding
+  - [x] 6.12 Write tests for privacy and public access
   - [ ] 6.13 Manual test sharing flow end-to-end
   
 - [ ] 7.0 Polish and Integration

--- a/test/controllers/help_controller_test.rb
+++ b/test/controllers/help_controller_test.rb
@@ -57,4 +57,29 @@ class HelpControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
     assert_equal help_next_month_setup_url, session[:return_to_after_authenticating]
   end
+
+  test "should redirect profile_sharing to login when not authenticated" do
+    get help_profile_sharing_path
+    assert_redirected_to new_session_path
+  end
+
+  test "should render profile_sharing page when authenticated" do
+    # Sign in
+    post session_url, params: {
+      email_address: @user.email_address,
+      password: "secure_password123"
+    }
+
+    get help_profile_sharing_path
+    assert_response :success
+    assert_select "h1", text: "Profile Sharing Help"
+    assert_select ".help-section", minimum: 5
+    assert_select "a[href='#{settings_path}'].settings-link", text: "<"
+  end
+
+  test "should set return_to_after_authenticating when redirecting profile_sharing" do
+    get help_profile_sharing_path
+    assert_redirected_to new_session_path
+    assert_equal help_profile_sharing_url, session[:return_to_after_authenticating]
+  end
 end

--- a/test/controllers/public_profiles_controller_test.rb
+++ b/test/controllers/public_profiles_controller_test.rb
@@ -1,0 +1,145 @@
+require "test_helper"
+
+class PublicProfilesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(
+      email_address: "profile@example.com",
+      password: "password123",
+      slug: "test-user",
+      habits_public: true,
+      reflections_public: true
+    )
+
+    # Create some test habits
+    @habit = @user.habits.create!(
+      name: "Exercise",
+      year: Date.current.year,
+      month: Date.current.month,
+      position: 1,
+      active: true,
+      check_type: "x_marks"
+    )
+
+    # Create a habit entry
+    @habit_entry = @habit.habit_entries.create!(
+      day: 1,
+      completed: true
+    )
+
+    # Create a reflection
+    @reflection = @user.daily_reflections.create!(
+      date: Date.current.beginning_of_month,
+      content: "Test reflection"
+    )
+  end
+
+  test "should show public profile for user with slug" do
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+    assert_select "h1", /#{Date.current.strftime("%B")}/
+    assert_select ".profile-user-name", "@#{@user.slug}"
+  end
+
+  test "should return 404 for non-existent slug" do
+    get public_profile_path(slug: "non-existent")
+    assert_response :not_found
+  end
+
+  test "should show habits when habits_public is true" do
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+    assert_select ".habit-name", @habit.name
+  end
+
+  test "should hide habits when habits_public is false" do
+    @user.update!(habits_public: false)
+
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+    assert_select ".habit-name", false
+  end
+
+  test "should show reflections when reflections_public is true" do
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+    assert_match @reflection.content, response.body
+  end
+
+  test "should hide reflections when reflections_public is false" do
+    @user.update!(reflections_public: false)
+
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+    assert_no_match @reflection.content, response.body
+  end
+
+  test "should show 404 when slug does not exist" do
+    get public_profile_path(slug: "does-not-exist")
+    assert_response :not_found
+  end
+
+  test "should allow unauthenticated access" do
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+  end
+
+  test "should show create account button for unauthenticated users" do
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+    assert_select ".create-account-button"
+  end
+
+  test "should not show create account button for authenticated users" do
+    sign_in_as(@user)
+
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+    assert_select ".create-account-button", false
+  end
+
+  test "should support year and month parameters" do
+    get public_profile_month_path(slug: @user.slug, year: 2025, month: 9)
+    assert_response :success
+    assert_select "h1", /September 2025/
+  end
+
+  test "should validate year and month parameters" do
+    # Invalid year
+    get public_profile_month_path(slug: @user.slug, year: 1999, month: 1)
+    assert_response :success
+    assert_select "h1", /#{Date.current.strftime("%B %Y")}/
+
+    # Invalid month
+    get public_profile_month_path(slug: @user.slug, year: 2025, month: 13)
+    assert_response :success
+    assert_select "h1", /#{Date.current.strftime("%B %Y")}/
+  end
+
+  test "should show attribution footer" do
+    get public_profile_path(slug: @user.slug)
+    assert_response :success
+    assert_select ".attribution", /verynormal\.dev/
+  end
+
+  test "should handle user with no habits gracefully" do
+    user_no_habits = User.create!(
+      email_address: "no-habits@example.com",
+      password: "password123",
+      slug: "no-habits",
+      habits_public: true
+    )
+
+    get public_profile_path(slug: user_no_habits.slug)
+    assert_response :success
+    assert_select ".empty-state"
+  end
+
+  private
+
+  def sign_in_as(user)
+    post session_path, params: {
+      email_address: user.email_address,
+      password: "password123"
+    }
+  end
+end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -43,7 +43,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
     # Check section titles
     assert_select "h2.settings-section-title", text: "Manage habits"
-    assert_select "h2.settings-section-title", text: "Profile & Sharing"
+    assert_select "h2.settings-section-title", text: "Profile sharing"
 
     # Month setup section should be hidden when user has no habits
     assert_select ".settings-section.month-setup", count: 0
@@ -78,7 +78,7 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
 
     # Check section titles
     assert_select "h2.settings-section-title", text: "Manage habits"
-    assert_select "h2.settings-section-title", text: "Profile & Sharing"
+    assert_select "h2.settings-section-title", text: "Profile sharing"
   end
 
   test "should hide back button when user has no habits" do

--- a/test/controllers/settings_profile_test.rb
+++ b/test/controllers/settings_profile_test.rb
@@ -1,0 +1,120 @@
+require "test_helper"
+
+class SettingsProfileTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(
+      email_address: "settings@example.com",
+      password: "password123"
+    )
+    sign_in_as(@user)
+  end
+
+  test "should update slug successfully" do
+    patch settings_path, params: {
+      user: {
+        slug: "new-slug",
+        habits_public: "false",
+        reflections_public: "false"
+      }
+    }
+
+    assert_redirected_to settings_path
+    assert_equal "Profile settings updated successfully", flash[:notice]
+
+    @user.reload
+    assert_equal "new-slug", @user.slug
+  end
+
+  test "should update privacy settings" do
+    patch settings_path, params: {
+      user: {
+        slug: @user.slug,
+        habits_public: "true",
+        reflections_public: "true"
+      }
+    }
+
+    assert_redirected_to settings_path
+
+    @user.reload
+    assert @user.habits_public?
+    assert @user.reflections_public?
+  end
+
+  test "should handle invalid slug format" do
+    patch settings_path, params: {
+      user: {
+        slug: "Invalid Slug!",
+        habits_public: "false",
+        reflections_public: "false"
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select ".field-error"
+
+    @user.reload
+    assert_not_equal "Invalid Slug!", @user.slug
+  end
+
+  test "should handle duplicate slug" do
+    other_user = User.create!(
+      email_address: "other@example.com",
+      password: "password123",
+      slug: "taken-slug"
+    )
+
+    patch settings_path, params: {
+      user: {
+        slug: "taken-slug",
+        habits_public: "false",
+        reflections_public: "false"
+      }
+    }
+
+    assert_response :unprocessable_entity
+
+    @user.reload
+    assert_not_equal "taken-slug", @user.slug
+  end
+
+  test "should allow clearing slug" do
+    @user.update!(slug: "existing-slug")
+
+    patch settings_path, params: {
+      user: {
+        slug: "",
+        habits_public: "false",
+        reflections_public: "false"
+      }
+    }
+
+    assert_redirected_to settings_path
+
+    @user.reload
+    assert_nil @user.slug
+  end
+
+  test "should require authentication" do
+    delete session_path # Sign out
+
+    patch settings_path, params: {
+      user: {
+        slug: "test",
+        habits_public: "false",
+        reflections_public: "false"
+      }
+    }
+
+    assert_redirected_to new_session_path
+  end
+
+  private
+
+  def sign_in_as(user)
+    post session_path, params: {
+      email_address: user.email_address,
+      password: "password123"
+    }
+  end
+end

--- a/test/models/user_public_profile_test.rb
+++ b/test/models/user_public_profile_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+class UserPublicProfileTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(
+      email_address: "test@example.com",
+      password: "password123"
+    )
+  end
+
+  # Slug validation tests
+  test "should accept valid slug formats" do
+    valid_slugs = [ "john-doe", "user_123", "test-user", "a12", "abc" ]
+
+    valid_slugs.each do |slug|
+      @user.slug = slug
+      assert @user.valid?, "Slug '#{slug}' should be valid"
+    end
+  end
+
+  test "should reject invalid slug formats" do
+    invalid_slugs = [ "user@123", "test user", "ab", "a" * 31, "user!" ]
+
+    invalid_slugs.each do |slug|
+      @user.slug = slug
+      assert_not @user.valid?, "Slug '#{slug}' should be invalid"
+    end
+  end
+
+  test "should enforce slug uniqueness" do
+    @user.update!(slug: "unique-slug")
+
+    other_user = User.new(
+      email_address: "other@example.com",
+      password: "password123",
+      slug: "unique-slug"
+    )
+
+    assert_not other_user.valid?
+    assert_includes other_user.errors[:slug], "has already been taken"
+  end
+
+  test "should normalize slug to lowercase" do
+    @user.slug = "MiXeD-CaSe"
+    @user.save!
+    @user.reload
+
+    assert_equal "mixed-case", @user.slug
+  end
+
+  test "slug should be optional" do
+    @user.slug = nil
+    assert @user.valid?
+
+    @user.slug = ""
+    assert @user.valid?
+  end
+
+  # Privacy settings tests
+  test "should default privacy settings to false" do
+    new_user = User.create!(
+      email_address: "new@example.com",
+      password: "password123"
+    )
+
+    assert_equal false, new_user.habits_public?
+    assert_equal false, new_user.reflections_public?
+  end
+
+  test "should track public profile status" do
+    assert_not @user.has_public_profile?
+
+    @user.slug = "test-user"
+    assert @user.has_public_profile?
+  end
+
+  test "should determine public habits visibility" do
+    @user.slug = "test-user"
+    @user.habits_public = false
+    assert_not @user.public_habits_visible?
+
+    @user.habits_public = true
+    assert @user.public_habits_visible?
+
+    @user.slug = nil
+    assert_not @user.public_habits_visible?
+  end
+
+  test "should determine public reflections visibility" do
+    @user.slug = "test-user"
+    @user.reflections_public = false
+    assert_not @user.public_reflections_visible?
+
+    @user.reflections_public = true
+    assert @user.public_reflections_visible?
+
+    @user.slug = nil
+    assert_not @user.public_reflections_visible?
+  end
+
+  test "with_slug scope should return users with slugs" do
+    @user.update!(slug: "has-slug")
+    user_without_slug = User.create!(
+      email_address: "no-slug@example.com",
+      password: "password123"
+    )
+
+    users_with_slugs = User.with_slug
+
+    assert_includes users_with_slugs, @user
+    assert_not_includes users_with_slugs, user_without_slug
+  end
+end

--- a/test/services/public_profile_data_builder_test.rb
+++ b/test/services/public_profile_data_builder_test.rb
@@ -1,0 +1,147 @@
+require "test_helper"
+
+class PublicProfileDataBuilderTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(
+      email_address: "test@example.com",
+      password: "password123",
+      slug: "test-user"
+    )
+
+    @year = Date.current.year
+    @month = Date.current.month
+
+    # Create test habits
+    @public_habit = @user.habits.create!(
+      name: "Public Habit",
+      year: @year,
+      month: @month,
+      position: 1,
+      active: true,
+      check_type: "x_marks"
+    )
+
+    @private_habit = @user.habits.create!(
+      name: "Private Habit",
+      year: @year,
+      month: @month,
+      position: 2,
+      active: true,
+      check_type: "blots"
+    )
+
+    # Create habit entries
+    @public_habit.habit_entries.create!(day: 1, completed: true)
+    @private_habit.habit_entries.create!(day: 2, completed: true)
+
+    # Create reflections
+    @reflection = @user.daily_reflections.create!(
+      date: Date.new(@year, @month, 3),
+      content: "Test reflection"
+    )
+  end
+
+  test "should return empty data when user has no public profile" do
+    @user.update!(slug: nil)
+
+    data = PublicProfileDataBuilder.call(user: @user, year: @year, month: @month)
+
+    assert data.empty?
+    assert_equal 0, data.habits.count
+    assert_empty data.habit_entries_lookup
+    assert_empty data.reflections_lookup
+  end
+
+  test "should include habits when habits_public is true" do
+    @user.update!(habits_public: true, reflections_public: false)
+
+    data = PublicProfileDataBuilder.call(user: @user, year: @year, month: @month)
+
+    assert_not data.empty?
+    assert_equal 2, data.habits.count
+    assert_includes data.habits, @public_habit
+    assert_includes data.habits, @private_habit
+    assert_not_empty data.habit_entries_lookup
+  end
+
+  test "should exclude habits when habits_public is false" do
+    @user.update!(habits_public: false, reflections_public: true)
+
+    data = PublicProfileDataBuilder.call(user: @user, year: @year, month: @month)
+
+    assert_equal 0, data.habits.count
+    assert_empty data.habit_entries_lookup
+  end
+
+  test "should include reflections when reflections_public is true" do
+    @user.update!(habits_public: false, reflections_public: true)
+
+    data = PublicProfileDataBuilder.call(user: @user, year: @year, month: @month)
+
+    assert_not_empty data.reflections_lookup
+    assert_equal @reflection, data.reflection_for(3)
+  end
+
+  test "should exclude reflections when reflections_public is false" do
+    @user.update!(habits_public: true, reflections_public: false)
+
+    data = PublicProfileDataBuilder.call(user: @user, year: @year, month: @month)
+
+    assert_empty data.reflections_lookup
+    assert_nil data.reflection_for(3)
+  end
+
+  test "should respect both privacy settings" do
+    @user.update!(habits_public: true, reflections_public: true)
+
+    data = PublicProfileDataBuilder.call(user: @user, year: @year, month: @month)
+
+    assert_not data.empty?
+    assert_equal 2, data.habits.count
+    assert_not_empty data.habit_entries_lookup
+    assert_not_empty data.reflections_lookup
+  end
+
+  test "should filter by specified year and month" do
+    # Create habit in different month
+    other_habit = @user.habits.create!(
+      name: "Other Month",
+      year: @year,
+      month: (@month % 12) + 1,
+      position: 1,
+      active: true,
+      check_type: "x_marks"
+    )
+
+    @user.update!(habits_public: true)
+
+    data = PublicProfileDataBuilder.call(user: @user, year: @year, month: @month)
+
+    assert_not_includes data.habits, other_habit
+  end
+
+  test "should only include active habits" do
+    @public_habit.update!(active: false)
+    @user.update!(habits_public: true)
+
+    data = PublicProfileDataBuilder.call(user: @user, year: @year, month: @month)
+
+    assert_not_includes data.habits, @public_habit
+    assert_includes data.habits, @private_habit
+  end
+
+  test "should raise error for nil user" do
+    assert_raises(ArgumentError) do
+      PublicProfileDataBuilder.call(user: nil, year: @year, month: @month)
+    end
+  end
+
+  test "should set correct month metadata" do
+    data = PublicProfileDataBuilder.call(user: @user, year: 2025, month: 9)
+
+    assert_equal "September", data.month_name
+    assert_equal 30, data.days_in_month
+    assert_equal 2025, data.year
+    assert_equal 9, data.month
+  end
+end


### PR DESCRIPTION
## Summary
- Adds public profile sharing functionality with custom URLs and granular privacy controls
- Users can share their habit tracking progress publicly while controlling what's visible
- Includes elegant read-only public views with appropriate CTAs for unauthenticated users

## Key Features
- **Custom Profile URLs**: Users can set custom slugs (e.g., verynormal.dev/jane-doe)
- **Privacy Controls**: Toggle public visibility for habits and reflections independently
- **Shared Architecture**: Created shared partials for consistent habit grid rendering between private and public views
- **Read-only Public Views**: Public profiles display habits and reflections in read-only mode
- **Empty States**: Elegant handling when users haven't shared data publicly
- **URL Copying**: One-click copying of public profile URLs

## Technical Implementation
- **Shared Partials**: Extracted habit grid into reusable partials with conditional rendering
- **Service Objects**: `PublicProfileDataBuilder` handles privacy-aware data building
- **Controller Architecture**: New `PublicProfilesController` for public views
- **Privacy Model**: Added public sharing fields to User model with validation
- **JavaScript Enhancement**: Stimulus controller for interactive settings management

## Test Coverage
- Comprehensive test suite covering all controllers, models, and services
- Privacy control validation and edge case handling
- Public profile access scenarios and empty states

## UI/UX Improvements
- Consistent styling between public and private views using shared components
- Mobile-responsive design for public profiles
- Clear visual feedback for privacy settings and URL copying
- Handwritten aesthetic maintained in public views

🤖 Generated with [Claude Code](https://claude.ai/code)