### PR TITLE
Fix line wrap in desktop daily reflections

### DIFF
--- a/app/assets/stylesheets/components/_reflections.scss
+++ b/app/assets/stylesheets/components/_reflections.scss
@@ -70,14 +70,12 @@
     display: none; /* Chrome/Safari */
   }
   
-  /* Desktop: Override mobile behavior to allow multi-line reflections */
+  /* Desktop: Keep single line with truncation - no line wrap */
   @media (min-width: 480px) {
-    white-space: normal;
-    word-wrap: break-word;
-    min-height: 2em; /* Allow for at least 2 lines */
-    max-height: 6em; /* Limit to reasonable height */
-    overflow-y: auto; /* Allow vertical scroll for very long content */
-    text-overflow: initial; /* Remove ellipsis for multi-line display */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-height: 1.4em; /* Single line height */
   }
   
   /* Empty state placeholder */
@@ -93,10 +91,11 @@
     overflow-x: auto;
     text-overflow: clip;
     
-    /* Desktop: Keep vertical scroll, no horizontal scroll needed */
+    /* Desktop: Enable horizontal scroll while editing, but keep single line */
     @media (min-width: 480px) {
-      overflow-x: hidden;
-      overflow-y: auto;
+      overflow-x: auto;
+      overflow-y: hidden;
+      white-space: nowrap;
     }
   }
   


### PR DESCRIPTION
## Summary
- Prevents line wrap in daily reflection entries on desktop views
- Long reflections now truncate with ellipsis instead of wrapping to multiple lines
- Mobile behavior remains unchanged (still uses existing mobile patterns)
- When focused, allows horizontal scrolling for editing while maintaining single line

## Test plan
- [ ] Test desktop view with long daily reflection text - should truncate with "..."
- [ ] Verify mobile view still works as before (no line wrap changes)
- [ ] Test editing long reflections on desktop - should allow horizontal scroll when focused
- [ ] Confirm no visual regressions in habit grid layout

🤖 Generated with [Claude Code](https://claude.ai/code)