### PR TITLE
fix: Apply ellipsis truncation to public profile reflections

### DIFF
--- a/app/assets/stylesheets/components/_public-profile.scss
+++ b/app/assets/stylesheets/components/_public-profile.scss
@@ -52,9 +52,19 @@
   background: none;
   border: none;
   
+  /* Prevent line wrap with ellipsis truncation */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  
   /* Handle simple_format paragraphs */
   p {
     margin: 0 0 var(--space-xs) 0;
+    
+    /* Apply truncation to paragraphs too */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     
     &:last-child {
       margin-bottom: 0;


### PR DESCRIPTION
## Summary
Extends the line wrap prevention fix from desktop daily reflections to public profile views. Long reflection text now shows "..." instead of wrapping to multiple lines, maintaining consistent visual design.

## Changes
- Applied `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` to `.reflection-content`
- Extended truncation to paragraph elements within reflections to handle `simple_format` output
- Maintains consistency with the recent fix applied to editable daily reflections

## Test plan
- [x] CSS builds successfully
- [x] Public profile reflections now truncate with ellipsis instead of wrapping
- [x] Visual consistency maintained across reflection displays

🤖 Generated with [Claude Code](https://claude.ai/code)