### PR TITLE
fix: Apply randomized check styles to public habit views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,12 +5,16 @@ module ApplicationHelper
 
   def render_public_habit_checkbox(habit_entry)
     content_tag(:div, class: "checkbox-container") do
+      # Extract the randomized style numbers from the stored enum values
+      box_number = habit_entry.checkbox_style.split("_").last
+      check_number = habit_entry.check_style.split("_").last
+
       if !habit_entry&.completed?
-        render("checkboxes/box_0")
+        render("checkboxes/box_#{box_number}")
       elsif habit_entry.habit.x_marks?
-        render("checkboxes/box_0") + render("checkboxes/x_0")
+        render("checkboxes/box_#{box_number}") + render("checkboxes/x_#{check_number}")
       else
-        render("checkboxes/box_0") + render("checkboxes/blot_0")
+        render("checkboxes/box_#{box_number}") + render("checkboxes/blot_#{check_number}")
       end
     end
   end


### PR DESCRIPTION
## Summary
- Fixed inconsistency where public habit views showed static checkbox styles while personal views showed randomized ones
- Modified `render_public_habit_checkbox` helper to use the stored randomized styles from habit entries
- Ensures the hand-drawn notebook aesthetic is consistent across both personal and public views

## Changes
- Updated `app/helpers/application_helper.rb` to extract and use the randomized style numbers stored in each habit entry
- Changed from hardcoded `box_0`, `x_0`, `blot_0` to dynamic variants based on stored enum values

## Test plan
- [x] All existing tests pass (255+ tests)
- [x] Public profiles controller tests pass (14/14)
- [x] Rubocop compliance verified
- [x] Manual verification that public views now show varied checkbox styles matching personal views

🤖 Generated with [Claude Code](https://claude.ai/code)