### PR TITLE
Improve public profile mobile layout

### DIFF
--- a/app/assets/stylesheets/components/_habit-tracking-layout.scss
+++ b/app/assets/stylesheets/components/_habit-tracking-layout.scss
@@ -73,7 +73,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 60px; /* Reduced from 80px for mobile */
+    height: 80px; /* Full height for habit names */
     position: relative;
     
     .habit-name {
@@ -98,7 +98,7 @@
   
   .reflection-column-header {
     flex-grow: 1;
-    height: 60px; /* Match habit column header height */
+    height: 80px; /* Match habit column header height */
     display: flex;
     align-items: flex-end; /* Align to bottom like habit headers */
     justify-content: center; /* Center the label horizontally */

--- a/app/assets/stylesheets/components/_habit-tracking-responsive.scss
+++ b/app/assets/stylesheets/components/_habit-tracking-responsive.scss
@@ -9,7 +9,7 @@
   }
   
   .habit-column-header .habit-name {
-    font-size: calc(var(--text-sm) * 0.9);
+    font-size: var(--text-xxs); /* Use proper token instead of calc */
   }
   
   .day-number {

--- a/app/assets/stylesheets/components/_public-profile.scss
+++ b/app/assets/stylesheets/components/_public-profile.scss
@@ -2,28 +2,24 @@
 /* PUBLIC PROFILE - Read-only habit tracker for sharing                        */
 /* ============================================================================ */
 
-/* Public profile header additions */
-.public-profile-info {
+/* Public profile CTA */
+.public-profile-cta {
   text-align: center;
   margin-top: var(--space-xs);
 }
 
-.profile-user-name {
+.create-account-link {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   color: var(--ink-primary);
   opacity: var(--opacity-secondary);
   letter-spacing: var(--letter-spacing-wide);
-}
-
-/* Create Account CTA for unauthenticated users */
-.create-account-cta {
-  margin-top: var(--space-lg);
-  text-align: center;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: opacity 0.2s ease;
   
-  /* Let the shared button partial handle all styling */
-  .canonical-button--secondary {
-    display: inline-flex;
+  &:hover {
+    opacity: 1;
   }
 }
 

--- a/app/views/public_profiles/show.html.erb
+++ b/app/views/public_profiles/show.html.erb
@@ -5,15 +5,10 @@
       
       <%# Header with user name and month/year %>
       <header class="month-header">
-        <h1><%= @tracker_data.month_name %> <%= @tracker_data.year %></h1>
-        <div class="public-profile-info">
-          <span class="profile-user-name">@<%= @user.slug %></span>
-        </div>
-        
-        <%# Create Account CTA for unauthenticated users %>
+        <h1><%= @tracker_data.month_name %> <%= @tracker_data.year %> - <%= @user.slug %></h1>
         <% unless authenticated? %>
-          <div class="create-account-cta">
-            <%= render 'shared/secondary_button', text: 'Create your own Gournal', url: new_user_path %>
+          <div class="public-profile-cta">
+            <a href="<%= new_user_path %>" class="create-account-link">Create your own Gournal</a>
           </div>
         <% end %>
       </header>

--- a/test/controllers/public_profiles_controller_test.rb
+++ b/test/controllers/public_profiles_controller_test.rb
@@ -37,7 +37,7 @@ class PublicProfilesControllerTest < ActionDispatch::IntegrationTest
     get public_profile_path(slug: @user.slug)
     assert_response :success
     assert_select "h1", /#{Date.current.strftime("%B")}/
-    assert_select ".profile-user-name", "@#{@user.slug}"
+    assert_select "h1", /#{@user.slug}/
   end
 
   test "should return 404 for non-existent slug" do
@@ -86,7 +86,7 @@ class PublicProfilesControllerTest < ActionDispatch::IntegrationTest
   test "should show create account button for unauthenticated users" do
     get public_profile_path(slug: @user.slug)
     assert_response :success
-    assert_select ".canonical-button--secondary"
+    assert_select ".create-account-link"
   end
 
   test "should not show create account button for authenticated users" do


### PR DESCRIPTION
## Summary
- Replaced large CTA button with inline underlined link to save vertical space
- Moved username inline with month/year header (September 2025 - mark)
- Restored full height for habit column headers (80px) to prevent truncation
- Fixed calc() antipattern by using proper design token
- Updated tests for new UI structure

## Test plan
- [x] All tests passing
- [x] CSS rebuilt successfully
- [x] Mobile layout no longer has overlapping text
- [x] Habit names display fully without truncation
- [x] CTA link appears cleanly below header

🤖 Generated with [Claude Code](https://claude.ai/code)