### PR TITLE
Fix Arc browser checkbox display issue

### DIFF
--- a/app/assets/stylesheets/components/_checkbox.scss
+++ b/app/assets/stylesheets/components/_checkbox.scss
@@ -58,7 +58,7 @@
   flex-shrink: 0;
 }
 
-.checkbox-box {
+div.checkbox-box {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -66,7 +66,7 @@
   left: 0;
 }
 
-.checkbox-box svg {
+svg.checkbox-box {
   width: 100%;
   height: 100%;
   overflow: visible;


### PR DESCRIPTION
## Summary
- Resolves checkbox rendering issues specific to Arc browser
- Makes CSS selectors more explicit to prevent style conflicts
- Minimal change that maintains behavior in all other browsers

## Problem
Arc browser was incorrectly applying `.checkbox-box` styles to both the container div and the SVG element, causing checkboxes to overlap and display incorrectly.

## Solution
Updated CSS selectors to be more specific:
- `.checkbox-box` → `div.checkbox-box` (targets container only)
- `.checkbox-box svg` → `svg.checkbox-box` (targets SVG element only)

## Test Plan
- [ ] Verify checkboxes display correctly in Arc browser
- [ ] Confirm no visual regression in Chrome
- [ ] Confirm no visual regression in Safari
- [ ] Confirm no visual regression in Firefox
- [ ] Test checkbox interactions still work properly

🤖 Generated with Claude Code