### PR TITLE
Fix header alignment issue with today indicator

### DIFF
--- a/app/assets/stylesheets/components/_habit-tracking-headers.scss
+++ b/app/assets/stylesheets/components/_habit-tracking-headers.scss
@@ -24,12 +24,22 @@
   opacity: var(--opacity-numbers);
   min-width: 20px;
   text-align: right;
-  margin-right: 8px; /* Reduced from 12px */
+  margin-right: 8px;
   letter-spacing: var(--letter-spacing-tight);
-  
+  position: relative;
+
   /* Precise vertical centering */
   height: var(--checkbox-size);
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
+
+  .today-indicator {
+    position: absolute;
+    left: -6px;
+  }
+
+  .day-value {
+    /* Keep original positioning */
+  }
 }

--- a/app/assets/stylesheets/components/_habit-tracking-headers.scss
+++ b/app/assets/stylesheets/components/_habit-tracking-headers.scss
@@ -38,8 +38,4 @@
     position: absolute;
     left: -6px;
   }
-
-  .day-value {
-    /* Keep original positioning */
-  }
 }

--- a/app/views/shared/_habit_grid_rows.html.erb
+++ b/app/views/shared/_habit_grid_rows.html.erb
@@ -6,12 +6,11 @@
       <%# Day Number %>
       <% today = Date.current.day %>
       <% is_current_month = tracker_data.year == Date.current.year && tracker_data.month == Date.current.month %>
-      <div class="day-number" style="width: 35px;">
+      <div class="day-number<%= ' day-number--today' if is_current_month && day == today %>">
         <% if is_current_month && day == today %>
-          • <%= day %>
-        <% else %>
-          <span style="margin-left: 9px;"><%= day %></span>
+          <span class="today-indicator">•</span>
         <% end %>
+        <%= day %>
       </div>
       
       <%# Habit Checkboxes %>


### PR DESCRIPTION
## Summary
- Fixed header misalignment caused by the recent today indicator feature
- Bullet point no longer shifts the day column layout
- Headers and day numbers now properly align

## Problem
The previous commit (5599fce) added a bullet point (•) to highlight today's date, but it caused:
1. Headers to misalign with day numbers
2. Day numbers to shift when the bullet appeared
3. Inconsistent column widths (35px vs 20px)

## Solution
- Used absolute positioning for the bullet indicator at `-6px` offset
- Reverted day column width back to original `20px` 
- Maintained consistent alignment whether bullet is present or not
- Removed unnecessary inline styles in favor of CSS classes

## Changes
- `app/views/shared/_habit_grid_rows.html.erb`: Simplified HTML structure, added semantic classes
- `app/assets/stylesheets/components/_habit-tracking-headers.scss`: Added absolute positioning for bullet, restored original widths

## Testing
- ✅ Headers align with day numbers
- ✅ Today's date shows bullet without shifting layout
- ✅ All days maintain consistent positioning
- ✅ Works on both current and non-current months

## Before & After
**Before:** Bullet shifted entire row, headers misaligned with 35px vs 20px mismatch
**After:** Bullet appears to the left without affecting layout, consistent 20px columns

🤖 Generated with [Claude Code](https://claude.ai/code)