### PR TITLE
Fix: habit reordering not reflected in tracker due to stale cache

### DIFF
--- a/app/services/habit_position_updater.rb
+++ b/app/services/habit_position_updater.rb
@@ -35,8 +35,9 @@ class HabitPositionUpdater
   end
 
   def reset_positions_to_negative
+    now = Time.current
     habits_scope.each_with_index do |habit, index|
-      habit.update_column(:position, -(index + 1))
+      habit.update_columns(position: -(index + 1), updated_at: now)
     end
   end
 
@@ -50,7 +51,7 @@ class HabitPositionUpdater
     habit = find_habit_by_id(position_data[:id])
     return unless habit && !position_data[:position].nil?
 
-    habit.update_column(:position, position_data[:position].to_i)
+    habit.update_columns(position: position_data[:position].to_i, updated_at: Time.current)
   end
 
   def find_habit_by_id(habit_id)


### PR DESCRIPTION
## Summary
- Fixes bug where reordering habits in settings doesn't appear on the habit tracker page until hard refresh
- Updates `updated_at` timestamp when positions change to invalidate HTTP cache
- Changes `update_column` to `update_columns` to include timestamp updates

## Root Cause
The `HabitPositionUpdater` service was using `update_column` which bypasses ActiveRecord callbacks and doesn't update the `updated_at` timestamp. This caused the `HabitDataTimestamp` service to return stale timestamps, making the browser cache think nothing had changed.

## Test plan
- [x] All existing tests pass (15 service tests, 9 controller tests)
- [x] Rubocop clean
- [ ] Manual: Reorder habits on settings page, verify changes appear immediately on tracker page

🤖 Generated with [Claude Code](https://claude.com/claude-code)