### PR TITLE
feat: Cloud Logging via gcplogs + JSON structured logging

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -70,6 +70,11 @@ volumes:
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
+logging:
+  driver: gcplogs
+  options:
+    gcp-project: very-normal
+
 asset_path: /rails/public/assets
 
 # Configure the image builder.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,9 @@ Rails.application.configure do
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  cloud_logger = ActiveSupport::Logger.new(STDOUT)
+  cloud_logger.formatter = CloudLoggingFormatter.new
+  config.logger = ActiveSupport::TaggedLogging.new(cloud_logger)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")

--- a/lib/cloud_logging_formatter.rb
+++ b/lib/cloud_logging_formatter.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "json"
+require "logger"
+
+# Formats log output as JSON compatible with Google Cloud Logging's structured logging format.
+# See: https://cloud.google.com/logging/docs/structured-logging
+#
+# When used with ActiveSupport::TaggedLogging, request tags (like request_id)
+# are included in the JSON labels rather than prepended to the message string.
+#
+# Cloud Error Reporting picks up errors automatically when the message contains
+# a Ruby-style backtrace (ErrorClass: message\n  path:line:in `method'...).
+class CloudLoggingFormatter < Logger::Formatter
+  SEVERITY_MAP = {
+    "DEBUG"   => "DEBUG",
+    "INFO"    => "INFO",
+    "WARN"    => "WARNING",
+    "ERROR"   => "ERROR",
+    "FATAL"   => "CRITICAL",
+    "UNKNOWN" => "DEFAULT"
+  }.freeze
+
+  def call(severity, time, _progname, message)
+    msg = message_to_s(message)
+
+    entry = {
+      severity: SEVERITY_MAP.fetch(severity, severity),
+      timestamp: time.utc.iso8601(3),
+      message: strip_tags(msg)
+    }
+
+    if respond_to?(:current_tags) && current_tags.present?
+      entry[:"logging.googleapis.com/labels"] = tags_as_labels
+    end
+
+    "#{entry.to_json}\n"
+  end
+
+  private
+
+  def message_to_s(message)
+    case message
+    when String then message
+    when nil    then ""
+    else             message.inspect
+    end
+  end
+
+  def strip_tags(message)
+    message.sub(/\A(\[[^\]]*\] )*/, "")
+  end
+
+  def tags_as_labels
+    tags = current_tags
+    labels = {}
+    labels[:request_id] = tags.first if tags.first.present?
+    tags.drop(1).each_with_index { |tag, i| labels[:"tag_#{i}"] = tag }
+    labels
+  end
+end


### PR DESCRIPTION
## Summary
- Switch production logging from plain-text STDOUT to JSON format compatible with Google Cloud Logging
- Docker's `gcplogs` driver sends container logs directly to Cloud Logging — no server-side config needed
- Cloud Error Reporting automatically picks up ERROR-severity entries with Ruby backtraces
- Fix pre-existing time-dependent test failure in `MonthSetupsControllerTest`

## Changes
- **New:** `lib/cloud_logging_formatter.rb` — JSON formatter with severity mapping, timestamp, structured labels
- **Updated:** `production.rb` wired to `CloudLoggingFormatter`
- **Updated:** `deploy.yml` adds `gcplogs` logging driver
- **Fixed:** `MonthSetupsControllerTest` — was creating habits for current month but `HabitCopyService` reads previous month relative to target; now uses fixed dates

## Breaking change
`kamal logs` will no longer work after deploy. Use `gcloud logging read` or Cloud Logging console instead.

## Test plan
- [x] 289 tests pass, 0 failures (was 1 pre-existing failure, now fixed)
- [ ] Deploy to gournal VM
- [ ] Verify logs appear in Cloud Logging console
- [ ] Trigger a test error, verify it appears in Cloud Error Reporting