### PR TITLE
fix: add require_relative for CloudLoggingFormatter

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
+  require_relative "../../lib/cloud_logging_formatter"
   cloud_logger = ActiveSupport::Logger.new(STDOUT)
   cloud_logger.formatter = CloudLoggingFormatter.new
   config.logger = ActiveSupport::TaggedLogging.new(cloud_logger)


### PR DESCRIPTION
## Summary
PR #71 added CloudLoggingFormatter but didn't require it in production.rb.
Asset precompilation fails during Docker build with `NameError: uninitialized constant CloudLoggingFormatter`.

Matches the pattern used in tts and js-notes.

## Test plan
- [ ] Deploy succeeds (asset precompilation passes)